### PR TITLE
Allow example in readme to compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ import (
 )
 
 func main() {
-    client := awx.NewAWX("http://awx.your_server_host.com", "your_awx_username", "your_awx_passwd", nil)
+    client, err := awx.NewAWX("http://awx.your_server_host.com", "your_awx_username", "your_awx_passwd", nil)
+    if err != nil {
+        log.Fatalf("AWX err: %s", err)
+    }
     result, err := client.PingService.Ping()
     if err != nil {
         log.Fatalf("Ping awx err: %s", err)


### PR DESCRIPTION
Fix the example in the README which is missing the error handling from client instantiation.