### PR TITLE
feat: use only one method to create AWX client

### DIFF
--- a/client/awx.go
+++ b/client/awx.go
@@ -75,6 +75,10 @@ func ValidateParams(data map[string]interface{}, mandatoryFields []string) (notf
 }
 
 func AWXClient(baseURL string, userName string, passwd string, token string, client *http.Client) (*AWX, error) {
+	if userName != "" && token != "" {
+		return nil, fmt.Errorf("please use only one authentication method: basic or token")
+	}
+
 	var r *Requester
 	if token != "" {
 		r = &Requester{Base: baseURL, Authenticator: &TokenAuth{Token: token}, Client: client}

--- a/examples/client.md
+++ b/examples/client.md
@@ -1,28 +1,48 @@
 # Creating a Client
 
-When using this SDK you're going to need to set up a client and establish a connection to the remote AWX/Tower
-instance. Here's an example of how you might go about doing this:
+When using this SDK you're going to need to set up a client and establish a connection to the remote AWX/Ansible Automation
+Platform instance.
 
+There are some parameters you can provide:
+
+* Your AWX/Tower DNS hostname or IP address (remembering to include the `http://` too)
+* Basic Auth:
+    * The username you wish to authenticate as
+    * The password you wish to authenticate with
+* Token Auth:
+    * The token you wish to authenticate with
+* And an optional `*http.Client` you can use to custom how the SDK communicates with your AWX/Tower instance(s)
+
+Throughout the rest of these example documents the above `client` variable will be referred to as a correctly
+configured client to an operational AWX/Tower instance.
+
+## Basic method
 ```go
 package main
 
 import (
     "log"
-    "github.com/denouche/goawx/client"
+    awx "github.com/denouche/goawx/client"
 )
 
 func main() {
-    client := awx.NewAWX("http://awx.your_server_host.com", "your_awx_username", "your_awx_passwd", nil)
+    client, err := awx.AWXClient("http://awx.your_server_host.com", "your_awx_username", "your_awx_passwd", "", nil)
     // ...
 }
 ```
 
-There are four parameters you can provide:
+## Token method
 
-* Your AWX/Tower DNS hostname or IP address (remembering to include the `http://` too)
-* The username you wish to authenticate as
-* The password you wish to authenticate with
-* And an optional `*http.Client` you can use to custom how the SDK communicates with your AWX/Tower instance(s)
+```go
+package main
 
-Throughout the rest of these example documents the above `client` variable will be referred to as a correctly
-configured client to an operational AWX/Tower instance.
+import (
+    awx "github.com/denouche/goawx/client"
+    "log"
+)
+
+func main() {
+    client, err := awx.AWXClient("http://awx.your_server_host.com", "", "", "my-token", nil)
+    // ...
+}
+```


### PR DESCRIPTION
NewAWX and NewAWXToken are deprecated. 
Please use AWXClient instead of